### PR TITLE
Fixed Issue #3 - Save tuning dialog dismissed on device rotation.

### DIFF
--- a/app/src/main/java/com/rohankhayech/choona/view/screens/TuningSelectionScreen.kt
+++ b/app/src/main/java/com/rohankhayech/choona/view/screens/TuningSelectionScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.compositeOver
@@ -118,7 +119,7 @@ fun TuningSelectionScreen(
         }}.value
     )
 
-    var showSaveDialog by remember { mutableStateOf(false) }
+    var showSaveDialog by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -433,7 +434,7 @@ private fun SaveTuningDialog(
     onSave: (String?, Tuning) -> Unit,
     onDismiss: () -> Unit
 ) {
-    var name by remember { mutableStateOf("") }
+    var name by rememberSaveable { mutableStateOf("") }
 
     AlertDialog(
         text = {


### PR DESCRIPTION
The save tuning dialog now persists through device rotation and other device configuration changes.

### Issues Fixed
- #3