### PR TITLE
Fixed custom tuning name persisting on main screen after deletion.

### DIFF
--- a/app/src/main/java/com/rohankhayech/choona/view/activity/TunerActivity.kt
+++ b/app/src/main/java/com/rohankhayech/choona/view/activity/TunerActivity.kt
@@ -183,6 +183,7 @@ class TunerActivity : AppCompatActivity() {
                         TuningSelectionScreen(
                             tuningList = vm.tuningList,
                             onSelect = ::selectTuning,
+                            onDelete = vm::onDeleteCustomTuning,
                             onDismiss = ::dismissTuningSelector,
                         )
                     }
@@ -337,6 +338,14 @@ class TunerActivityViewModel : ViewModel() {
     fun openTuningSelector() {
         tuningList.setCurrent(tuner.tuning.value)
         _tuningSelectorOpen.update { true }
+    }
+
+    /** Called when the specified [tuning] is deleted. */
+    fun onDeleteCustomTuning(tuning: Tuning) {
+        // Reset the name of the current tuning if it is equivalent to the custom tuning.
+        if (tuner.tuning.value.equivalentTo(tuning)) {
+            tuner.setTuning(Tuning(null, tuning))
+        }
     }
 
     /** Dismisses the tuning selection screen. */

--- a/app/src/main/java/com/rohankhayech/choona/view/screens/TuningSelectionScreen.kt
+++ b/app/src/main/java/com/rohankhayech/choona/view/screens/TuningSelectionScreen.kt
@@ -52,7 +52,10 @@ import com.rohankhayech.music.Tuning
  * as well as managing favourite and custom tunings.
  *
  * @param tuningList State holder for the tuning list.
+ * @param onSave Called when a custom tuning is saved with the specified name.
+ * @param onFavouriteSet Called when a tuning is favourited or unfavourited.
  * @param onSelect Called when a tuning is selected.
+ * @param onDelete Called when a custom tuning is deleted.
  * @param onDismiss Called when the screen is dismissed.
  *
  * @author Rohan Khayech
@@ -60,7 +63,10 @@ import com.rohankhayech.music.Tuning
 @Composable
 fun TuningSelectionScreen(
     tuningList: TuningList,
+    onSave: (String?, Tuning) -> Unit = {_,_->},
+    onFavouriteSet: (Tuning, Boolean) -> Unit = {_,_->},
     onSelect: (Tuning) -> Unit,
+    onDelete: (Tuning) -> Unit = {},
     onDismiss: () -> Unit
 ) {
     // Collect UI state.
@@ -73,10 +79,19 @@ fun TuningSelectionScreen(
         common = Tunings.COMMON,
         favourites = favourites,
         custom = custom,
-        onSave = tuningList::addCustom,
-        onFavouriteSet = tuningList::setFavourited,
+        onSave = { name, tuning ->
+            tuningList.addCustom(name, tuning)
+            onSave(name, tuning)
+        },
+        onFavouriteSet = { tuning, fav ->
+            tuningList.setFavourited(tuning, fav)
+            onFavouriteSet(tuning, fav)
+        },
         onSelect = onSelect,
-        onDelete = tuningList::removeCustom,
+        onDelete = {
+            tuningList.removeCustom(it)
+            onDelete(it)
+        },
         onDismiss = onDismiss
     )
 }


### PR DESCRIPTION
The previously saved name is now no longer displayed on the tuning selection dropdown on the main screen after the custom tuning is deleted.

### Issues Fixed
- Fixed #5