### PR TITLE
Hotfix: v1.4.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         applicationId = "com.rohankhayech.choona"
         minSdk = 24
         targetSdk = 35
-        versionCode = 8
-        versionName = "1.4.0"
+        versionCode = 9
+        versionName = "1.4.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutLibraries = "12.1.2"
 agp = "8.10.0"
-datastorePreferencesVersion = "1.1.6"
+datastorePreferencesVersion = "1.1.7"
 jsonVersion = "20231013"
 kotlinxCoroutinesTest = "1.7.3"
 lifecycleRuntimeCompose = "2.9.0"


### PR DESCRIPTION
Patch release to fix crash on app load after updating.

### Fixes
- Fixed app crashing while loading preferences from older versions of the app, due to an issue with AndroidX Preference DataStore. See [related issue](https://developer.android.com/jetpack/androidx/releases/datastore#1.1.7).

### Technical Changes
- Updated AndroidX Preferences DataStore library to v1.1.7