### PR TITLE
Feature: In-App Review

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.review.ktx)
 
     // Compose
     val composeBOM = platform(libs.androidx.compose.bom)

--- a/app/src/main/java/com/rohankhayech/choona/model/preferences/TunerPreferences.kt
+++ b/app/src/main/java/com/rohankhayech/choona/model/preferences/TunerPreferences.kt
@@ -49,6 +49,7 @@ data class TunerPreferences(
     val useDynamicColor: Boolean = DEFAULT_USE_DYNAMIC_COLOR,
     val editModeDefault: Boolean = DEFAULT_EDIT_MODE_DEFAULT,
     val initialTuning: InitialTuningType = DEFAULT_INITIAL_TUNING,
+    val showReviewPrompt: Boolean = DEFAULT_SHOW_REVIEW_PROMPT,
     val reviewPromptLaunches: Int = 0
 ) {
     companion object {
@@ -61,6 +62,7 @@ data class TunerPreferences(
         val USE_DYNAMIC_COLOR_KEY = booleanPreferencesKey("use_dynamic_color")
         val EDIT_MODE_DEFAULT_KEY = booleanPreferencesKey("edit_mode_default")
         val INITIAL_TUNING_KEY = stringPreferencesKey("initial_tuning")
+        val SHOW_REVIEW_PROMPT_KEY = booleanPreferencesKey("show_review_prompt")
         val REVIEW_PROMPT_LAUNCHES_KEY = stringPreferencesKey("review_prompt_launches")
 
         // Defaults
@@ -72,6 +74,8 @@ data class TunerPreferences(
         const val DEFAULT_EDIT_MODE_DEFAULT = false
         val DEFAULT_INITIAL_TUNING = InitialTuningType.PINNED
         const val DEFAULT_USE_DYNAMIC_COLOR = false
+        const val DEFAULT_SHOW_REVIEW_PROMPT = true
+
         /** Maximum number of times to prompt the user for a review. */
         const val REVIEW_PROMPT_ATTEMPTS = 3
 
@@ -87,8 +91,8 @@ data class TunerPreferences(
                 useBlackTheme = prefs[USE_BLACK_THEME_KEY] ?: DEFAULT_USE_BLACK_THEME,
                 useDynamicColor = prefs[USE_DYNAMIC_COLOR_KEY] ?: DEFAULT_USE_DYNAMIC_COLOR,
                 editModeDefault = prefs[EDIT_MODE_DEFAULT_KEY] ?: DEFAULT_EDIT_MODE_DEFAULT,
-                initialTuning = prefs[INITIAL_TUNING_KEY]?.let { InitialTuningType.valueOf(it) } ?: DEFAULT_INITIAL_TUNING
                 initialTuning = prefs[INITIAL_TUNING_KEY]?.let { InitialTuningType.valueOf(it) } ?: DEFAULT_INITIAL_TUNING,
+                showReviewPrompt = prefs[SHOW_REVIEW_PROMPT_KEY] ?: DEFAULT_SHOW_REVIEW_PROMPT,
                 reviewPromptLaunches = prefs[REVIEW_PROMPT_LAUNCHES_KEY]?.toIntOrNull() ?: 0
             )
         }

--- a/app/src/main/java/com/rohankhayech/choona/model/preferences/TunerPreferences.kt
+++ b/app/src/main/java/com/rohankhayech/choona/model/preferences/TunerPreferences.kt
@@ -49,6 +49,7 @@ data class TunerPreferences(
     val useDynamicColor: Boolean = DEFAULT_USE_DYNAMIC_COLOR,
     val editModeDefault: Boolean = DEFAULT_EDIT_MODE_DEFAULT,
     val initialTuning: InitialTuningType = DEFAULT_INITIAL_TUNING,
+    val reviewPromptLaunches: Int = 0
 ) {
     companion object {
         // Keys
@@ -60,6 +61,7 @@ data class TunerPreferences(
         val USE_DYNAMIC_COLOR_KEY = booleanPreferencesKey("use_dynamic_color")
         val EDIT_MODE_DEFAULT_KEY = booleanPreferencesKey("edit_mode_default")
         val INITIAL_TUNING_KEY = stringPreferencesKey("initial_tuning")
+        val REVIEW_PROMPT_LAUNCHES_KEY = stringPreferencesKey("review_prompt_launches")
 
         // Defaults
         const val DEFAULT_ENABLE_STRING_SELECT_SOUND = true
@@ -70,6 +72,8 @@ data class TunerPreferences(
         const val DEFAULT_EDIT_MODE_DEFAULT = false
         val DEFAULT_INITIAL_TUNING = InitialTuningType.PINNED
         const val DEFAULT_USE_DYNAMIC_COLOR = false
+        /** Maximum number of times to prompt the user for a review. */
+        const val REVIEW_PROMPT_ATTEMPTS = 3
 
         /**
          * Maps the specified android [preferences][prefs] to a [TunerPreferences] object.
@@ -84,6 +88,8 @@ data class TunerPreferences(
                 useDynamicColor = prefs[USE_DYNAMIC_COLOR_KEY] ?: DEFAULT_USE_DYNAMIC_COLOR,
                 editModeDefault = prefs[EDIT_MODE_DEFAULT_KEY] ?: DEFAULT_EDIT_MODE_DEFAULT,
                 initialTuning = prefs[INITIAL_TUNING_KEY]?.let { InitialTuningType.valueOf(it) } ?: DEFAULT_INITIAL_TUNING
+                initialTuning = prefs[INITIAL_TUNING_KEY]?.let { InitialTuningType.valueOf(it) } ?: DEFAULT_INITIAL_TUNING,
+                reviewPromptLaunches = prefs[REVIEW_PROMPT_LAUNCHES_KEY]?.toIntOrNull() ?: 0
             )
         }
     }

--- a/app/src/main/java/com/rohankhayech/choona/model/preferences/TunerPreferences.kt
+++ b/app/src/main/java/com/rohankhayech/choona/model/preferences/TunerPreferences.kt
@@ -36,6 +36,8 @@ import androidx.datastore.preferences.preferencesDataStore
  * @property useDynamicColor Whether to use dynamic color for the app theme.
  * @property editModeDefault Whether to enable tuning edit functionality.
  * @property initialTuning The default tuning used when opening the app.
+ * @property showReviewPrompt Whether the user can be prompted for a review.
+ * @property reviewPromptLaunches Number of times the review prompt has been shown.
  *
  * @author Rohan Khayech
  */

--- a/app/src/main/java/com/rohankhayech/choona/view/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/rohankhayech/choona/view/activity/SettingsActivity.kt
@@ -137,8 +137,10 @@ class SettingsActivity : ComponentActivity() {
                             onBackPressed = ::finish
                         )
                         Screen.ABOUT -> AboutScreen(
+                            prefs,
                             onLicencesPressed = ::openLicencesScreen,
-                            onBackPressed = ::dismissAboutScreen
+                            onBackPressed = ::dismissAboutScreen,
+                            onReviewOptOut = vm::optOutOfReviewPrompt
                         )
                         Screen.LICENCES -> LicencesScreen(onBackPressed = ::dismissLicencesScreen)
                     }
@@ -232,6 +234,11 @@ private class SettingsActivityViewModel(
     /** Sets the [initialTuning] to be used when the app is first opened. */
     fun setInitialTuning(initialTuning: InitialTuningType) {
         setPreference(TunerPreferences.INITIAL_TUNING_KEY, initialTuning.toString())
+    }
+
+    /** Opts the user out of future review prompts. */
+    fun optOutOfReviewPrompt() {
+        setPreference(TunerPreferences.SHOW_REVIEW_PROMPT_KEY, false)
     }
 
     /** Sets the preference with the specified [key] to the specified [value]. */

--- a/app/src/main/java/com/rohankhayech/choona/view/screens/AboutScreen.kt
+++ b/app/src/main/java/com/rohankhayech/choona/view/screens/AboutScreen.kt
@@ -72,7 +72,10 @@ import kotlinx.coroutines.launch
 
 /**
  * UI screen displaying version, copyright and license information about the app.
+ * @param prefs User preferences for the tuner.
+ * @param onLicencesPressed Called when the licenses item is pressed
  * @param onBackPressed Called when the back navigation button is pressed.
+ * @param onReviewOptOut Called when the user opts out of review prompts.
  * @author Rohan Khayech
  */
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/rohankhayech/choona/view/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/rohankhayech/choona/view/screens/SettingsScreen.kt
@@ -321,7 +321,7 @@ private fun Preview() {
             onToggleEditModeDefault = {},
             onSelectInitialTuning = {},
             onAboutPressed = {},
-            onBackPressed = {},
+            onBackPressed = {}
         )
     }
 }

--- a/app/src/main/java/com/rohankhayech/choona/view/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/rohankhayech/choona/view/screens/SettingsScreen.kt
@@ -69,8 +69,9 @@ import com.rohankhayech.music.Tuning
  * @param onEnableInTuneSound Called when the user toggles the in-tune sound.
  * @param onSetUseBlackTheme Called when the user toggles the full black theme.
  * @param onSetUseDynamicColor Called when the user toggles the dynamic color feature.
- * @param onSelectInitialTuning Called when the user selects the initial tuning type.
  * @param onToggleEditModeDefault Called when the user toggles the edit mode feature.
+ * @param onSelectInitialTuning Called when the user selects the initial tuning type.
+ * @param onAboutPressed Called when the user presses the about option.
  * @param onBackPressed Called when the user presses the back navigation button.
  *
  * @author Rohan Khayech

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -108,4 +108,8 @@
     <string name="error_title">Error</string>
     <string name="error_description">Sorry, the following error occurred preventing the tuner from running:</string>
     <string name="error_action_call">Please restart the application to retry.</string>
+    <string name="pref_review_opt_out">Opt-out of review prompts</string>
+    <string name="pref_review_opt_out_desc">Don\'t ask me to review the app again.</string>
+    <string name="rate_app">Rate and review</string>
+    <string name="review_opted_out">You won\'t be asked to review the app again.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,4 +109,8 @@
     <string name="error_title">Error</string>
     <string name="error_description">Sorry, the following error occurred preventing the tuner from running:</string>
     <string name="error_action_call">Please restart the application to retry.</string>
+    <string name="pref_review_opt_out">Opt-out of review prompts</string>
+    <string name="pref_review_opt_out_desc">Don\'t ask me to review the app again.</string>
+    <string name="rate_app">Rate and review</string>
+    <string name="review_opted_out">You won\'t be asked to review the app again.</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2025.08.00"
+reviewKtx = "2.0.2"
 
 [libraries]
 aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutLibraries" }
@@ -45,6 +46,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidutils-theme = { module = "com.github.rohankhayech.AndroidUtils:theme-m3", version.ref = "androidUtils" }
 ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+review-ktx = { group = "com.google.android.play", name = "review-ktx", version.ref = "reviewKtx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Added an in-app review prompt to drive user growth and discovery.

- Users are now occasionally prompted to rate and review the app on Google Play, once all strings are tuned.
- The prompt is only shown once per app session and each user is prompted a maximum of 3 times.
- Users can opt-out of being shown review prompts in the app's settings.